### PR TITLE
encode special character too

### DIFF
--- a/R/geonames.R
+++ b/R/geonames.R
@@ -56,7 +56,7 @@ getJson=function(name,plist){
   }
   olist = list()
   for(p in 1:length(plist)){
-    olist[[p]]=paste(names(plist)[p],"=",URLencode(as.character(plist[[p]])),sep="")
+    olist[[p]]=paste(names(plist)[p],"=",URLencode(as.character(plist[[p]]),reserved=TRUE),sep="")
   }
   pstring=paste(unlist(olist),collapse="&")
   url=paste(url,pstring,sep='')  


### PR DESCRIPTION
I ran into an issue today using GNsearch(...) when a location I wanted to geolocate had the "#" character in it. Really this was a data cleaning error in my case, but a search of geonames does show there are valid locations with the # character. Example of the error: 
```
GNsearch(q="South Fork #10 Dam")
Error in getJson(name, params) : 
  error code 10 from server: Please add a username to each call in order for geonames to be able to identify the calling application and count the credits usage
```
By default, URLencode does not encode the "#" and other special characters and this leads to the API rejecting the call. This pull request tells URLencode to encode these special characters. With this change, GNsearch works for all my data. After the change in this pull request:

```
GNsearch(q="South Fork #10 Dam")
  adminCode1       lng geonameId        toponymName countryId fcl population
1         WV -79.19198   4803581 South Fork #10 Dam   6252001   S          0
  countryCode               name              fclName   countryName fcodeName
1          US South Fork #10 Dam spot, building, farm United States       dam
     adminName1      lat fcode
1 West Virginia 38.66178   DAM
```


Thank you for the great work on this package!

