### PR TITLE
Bump version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: geonames
 Type: Package
 Title: Interface To www.geonames.org Spatial Query Web Service
-Version: 0.998
+Version: 0.998.9000
 Date: 2011-24-11
 Author: Barry Rowlingson
 Maintainer: Barry Rowlingson <b.rowlingson@gmail.com>


### PR DESCRIPTION
Since the development version of the package contains functionality not yet in the CRAN version (especially #13) it'd be nice for the version numbers to differ as well, so I can specify dependencies on the new version, e.g. `Imports: geonames (> 0.998)`.

I've used the Tidyverse convention here of adding ".9000" to indicate the dev version, but I'm not attached to it -- if you prefer something like 0.999, that works just as well for me.